### PR TITLE
Fixed forEach iterator TypeError, made localStorage usage easier

### DIFF
--- a/build/dat.gui.js
+++ b/build/dat.gui.js
@@ -106,8 +106,9 @@ dat.utils.common = (function () {
     
     each: function(obj, itr, scope) {
 
-      
-      if (ARR_EACH && obj.forEach === ARR_EACH) { 
+      if (!obj) return;
+
+      if (ARR_EACH && obj.forEach && obj.forEach === ARR_EACH) { 
         
         obj.forEach(itr, scope);
         
@@ -779,6 +780,8 @@ dat.controllers.NumberController = (function (Controller, common) {
          */
         step: function(v) {
           this.__step = v;
+          this.__impliedStep = v;
+          this.__precision = numDecimals(v);
           return this;
         }
 
@@ -1671,6 +1674,8 @@ dat.GUI = dat.gui.GUI = (function (css, saveDialogueContents, styleSheet, contro
         SUPPORTS_LOCAL_STORAGE &&
             localStorage.getItem(getLocalStorageHash(this, 'isLocal')) === 'true';
 
+    var saveToLocalStorage;
+
     Object.defineProperties(this,
 
         /** @lends dat.gui.GUI.prototype */
@@ -1926,9 +1931,14 @@ dat.GUI = dat.gui.GUI = (function (css, saveDialogueContents, styleSheet, contro
       addResizeHandle(this);
     }
 
-    function saveToLocalStorage() {
-      localStorage.setItem(getLocalStorageHash(_this, 'gui'), JSON.stringify(_this.getSaveObject()));
+    saveToLocalStorage = function () {
+      if (SUPPORTS_LOCAL_STORAGE && localStorage.getItem(getLocalStorageHash(_this, 'isLocal')) === 'true') {
+        localStorage.setItem(getLocalStorageHash(_this, 'gui'), JSON.stringify(_this.getSaveObject()));
+      }
     }
+
+    // expose this method publicly
+    this.saveToLocalStorageIfPossible = saveToLocalStorage;
 
     var root = _this.getRoot();
     function resetWidth() {
@@ -2226,6 +2236,7 @@ dat.GUI = dat.gui.GUI = (function (css, saveDialogueContents, styleSheet, contro
 
           this.load.remembered[this.preset] = getCurrentPreset(this);
           markPresetModified(this, false);
+          this.saveToLocalStorageIfPossible();
 
         },
 
@@ -2242,6 +2253,7 @@ dat.GUI = dat.gui.GUI = (function (css, saveDialogueContents, styleSheet, contro
           this.load.remembered[presetName] = getCurrentPreset(this);
           this.preset = presetName;
           addPresetOption(this, presetName, true);
+          this.saveToLocalStorageIfPossible();
 
         },
 

--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -179,6 +179,8 @@ define([
         SUPPORTS_LOCAL_STORAGE &&
             localStorage.getItem(getLocalStorageHash(this, 'isLocal')) === 'true';
 
+    var saveToLocalStorage;
+
     Object.defineProperties(this,
 
         /** @lends dat.gui.GUI.prototype */
@@ -434,9 +436,14 @@ define([
       addResizeHandle(this);
     }
 
-    function saveToLocalStorage() {
-      localStorage.setItem(getLocalStorageHash(_this, 'gui'), JSON.stringify(_this.getSaveObject()));
+    saveToLocalStorage = function () {
+      if (SUPPORTS_LOCAL_STORAGE && localStorage.getItem(getLocalStorageHash(_this, 'isLocal')) === 'true') {
+        localStorage.setItem(getLocalStorageHash(_this, 'gui'), JSON.stringify(_this.getSaveObject()));
+      }
     }
+
+    // expose this method publicly
+    this.saveToLocalStorageIfPossible = saveToLocalStorage;
 
     var root = _this.getRoot();
     function resetWidth() {
@@ -734,6 +741,7 @@ define([
 
           this.load.remembered[this.preset] = getCurrentPreset(this);
           markPresetModified(this, false);
+          this.saveToLocalStorageIfPossible();
 
         },
 
@@ -750,6 +758,7 @@ define([
           this.load.remembered[presetName] = getCurrentPreset(this);
           this.preset = presetName;
           addPresetOption(this, presetName, true);
+          this.saveToLocalStorageIfPossible();
 
         },
 

--- a/src/dat/utils/common.js
+++ b/src/dat/utils/common.js
@@ -68,8 +68,9 @@ define([
     
     each: function(obj, itr, scope) {
 
-      
-      if (ARR_EACH && obj.forEach === ARR_EACH) { 
+      if (!obj) return;
+
+      if (ARR_EACH && obj.forEach && obj.forEach === ARR_EACH) { 
         
         obj.forEach(itr, scope);
         


### PR DESCRIPTION
> This pull request fixes **[two bugs causing grief on the google-hosted repo of dat.gui](https://code.google.com/p/dat-gui/issues/detail?id=13)**.
### No Controllers Yet TypeError

People including myself have been getting _TypeError_'s thrown by `each(obj, iter, scope)` in `utils/common.js`. This occurs if you try to save a preset and happened to call `gui.remember()` too late _after_ creating controllers.

Instead of an exception being the behavior, I added a condition test to `obj` and `obj.forEach` to see if either the tested object or iterator exist before attempting `.forEach()`.
### Unreliable LocalStorage

The localStorage save feature only fires as a DOM event on window close, which seems kind of ridiculous. The fix was even harder to hunt down, because the `saveToLocalStorage()` function is private and only exposed within the scope of declaring GUI's getters and setters. GUI's methods can't even call it!

I have no idea why this is the case.

I exposed the `saveToLocalStorage()` method via `GUI.saveToLocalStorageIfPossible()` and added calls to it within `GUI.save()` and `GUI.saveAs()`, because if the feature is enabled, I would consider saving to localStorage upon clicking either to be "expected behavior".
