### PR TITLE
display none/block for hiding

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -464,8 +464,7 @@ define([
 
     hide = !hide;
     common.each(hideable_guis, function(gui) {
-      gui.domElement.style.zIndex = hide ? -999 : 999;
-      gui.domElement.style.opacity = hide ? 0 : 1;
+      gui.domElement.style.display = hide ? 'none' : 'fixed';
     });
   };
 


### PR DESCRIPTION
negative z-index does not always prevent dat.gui from occluding over existing elements when hidden.