### PR TITLE
missing step argument and improvements for Number Controllers

### DIFF
--- a/src/dat/controllers/NumberControllerBox.js
+++ b/src/dat/controllers/NumberControllerBox.js
@@ -85,7 +85,9 @@ define([
     }
 
     function onMouseDrag(e) {
-
+      
+      document.activeElement.blur();
+      
       var diff = prev_y - e.clientY;
       _this.setValue(_this.getValue() + diff * _this.__impliedStep);
 
@@ -114,7 +116,7 @@ define([
       {
 
         updateDisplay: function() {
-
+          if (dom.isActive(this.__input)) return;
           this.__input.value = this.__truncationSuspended ? this.getValue() : roundToDecimal(this.getValue(), this.__precision);
           return NumberControllerBox.superclass.prototype.updateDisplay.call(this);
         }

--- a/src/dat/controllers/NumberControllerSlider.js
+++ b/src/dat/controllers/NumberControllerSlider.js
@@ -55,7 +55,9 @@ function(NumberController, dom, css, common, styleSheet) {
     dom.addClass(this.__foreground, 'slider-fg');
 
     function onMouseDown(e) {
-
+      
+      document.activeElement.blur();
+      
       dom.bind(window, 'mousemove', onMouseDrag);
       dom.bind(window, 'mouseup', onMouseUp);
 

--- a/src/dat/controllers/factory.js
+++ b/src/dat/controllers/factory.js
@@ -37,12 +37,18 @@ define([
 
           if (common.isNumber(arguments[2]) && common.isNumber(arguments[3])) {
 
-            // Has min and max.
-            return new NumberControllerSlider(object, property, arguments[2], arguments[3]);
+        	// Has min and max.
+            if (common.isNumber(arguments[4])) // has step
+              return new NumberControllerSlider(object, property, arguments[2], arguments[3], arguments[4]);
+            else
+              return new NumberControllerSlider(object, property, arguments[2], arguments[3]);
 
           } else {
 
-            return new NumberControllerBox(object, property, { min: arguments[2], max: arguments[3] });
+        	if (common.isNumber(arguments[4]))
+              return new NumberControllerBox(object, property, { min: arguments[2], max: arguments[3], step: arguments[4] });
+          	else
+              return new NumberControllerBox(object, property, { min: arguments[2], max: arguments[3] });
 
           }
 

--- a/src/dat/gui/style.css
+++ b/src/dat/gui/style.css
@@ -273,7 +273,8 @@
     background: #303030;
     cursor: ew-resize; }
   .dg .c .slider-fg {
-    background: #2fa1d6; }
+    background: #2fa1d6;
+    max-width: 100%; }
   .dg .c .slider:hover {
     background: #3c3c3c; }
     .dg .c .slider:hover .slider-fg {


### PR DESCRIPTION
add(…).min().max().step() does not work for me. For testing purpose use
a starting value of 0. add() will return the NumberControllerSlider and
the following function calls min() max() step() won’t reach the
corresponding NumberControllerBox.

For the shorthand call add(…, min, max, step) was the step argument
missing in the factory.js. This merge request will fix this but the
other bug remains (also see #45).

I Also added some improvements for the Number Controllers in my second commit:
-adds the ability to change the value in the Number box while the controller is listening via .listen().
-Prevents the slider bar from being wider than than 100%.

I'm not sure if document.activeElement.blur() is proper, but it does the trick.