### PR TITLE
Added requestAnimationFrame

### DIFF
--- a/src/dat/utils/requestAnimationFrame.js
+++ b/src/dat/utils/requestAnimationFrame.js
@@ -19,7 +19,8 @@ define([
    * http://paulirish.com/2011/requestanimationframe-for-smart-animating/
    */
 
-  return window.webkitRequestAnimationFrame ||
+  return window.requestAnimationFrame ||
+      window.webkitRequestAnimationFrame ||
       window.mozRequestAnimationFrame ||
       window.oRequestAnimationFrame ||
       window.msRequestAnimationFrame ||


### PR DESCRIPTION
To fix the warning `'webkitRequestAnimationFrame' is vendor-specific. Please use the standard 'requestAnimationFrame' instead.` in more recent versions of Chrome