### PR TITLE
Fixed removing a controller from a folder

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -544,7 +544,7 @@ define([
 
           // TODO listening?
           this.__ul.removeChild(controller.__li);
-          this.__controllers.slice(this.__controllers.indexOf(controller), 1);
+          this.__controllers = this.__controllers.slice(this.__controllers.indexOf(controller), 1);
           var _this = this;
           common.defer(function() {
             _this.onResize();


### PR DESCRIPTION
According to js specs, the `slice` method doesn't change the original
array. Therefore, we have to reassign `__controllers` to
`this.__controllers` after slicing.
