### PR TITLE
added custom name support for NumberControllerSlider

### DIFF
--- a/src/dat/controllers/NumberControllerBox.js
+++ b/src/dat/controllers/NumberControllerBox.js
@@ -117,7 +117,8 @@ define([
 
           this.__input.value = this.__truncationSuspended ? this.getValue() : roundToDecimal(this.getValue(), this.__precision);
           return NumberControllerBox.superclass.prototype.updateDisplay.call(this);
-        }
+        },
+        name: function() {}
 
       }
 

--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -927,7 +927,7 @@ define([
       var box = new NumberControllerBox(controller.object, controller.property,
           { min: controller.__min, max: controller.__max, step: controller.__step });
 
-      common.each(['updateDisplay', 'onChange', 'onFinishChange'], function(method) {
+      common.each(['updateDisplay', 'onChange', 'onFinishChange', 'name'], function(method) {
         var pc = controller[method];
         var pb = box[method];
         controller[method] = box[method] = function() {


### PR DESCRIPTION
In the current version, calling `.name()` on a `NumberControllerSlider` results in an `undefined is not a function` error since the controller doesn't have such a function.

I added a rough version of it, since I couldn't quite figure out why it would be lost in the `common.extend` function call.