### PR TITLE
Fixed the precision bug for displayed value of sliders

### DIFF
--- a/src/dat/controllers/NumberController.js
+++ b/src/dat/controllers/NumberController.js
@@ -124,6 +124,11 @@ define([
           this.__step = v;
           this.__impliedStep = v;
           this.__precision = numDecimals(v);
+          if (this.__valueControllerBox !== undefined) {
+            this.__valueControllerBox.__step = this.__step;
+            this.__valueControllerBox.__impliedStep = this.__impliedStep;
+            this.__valueControllerBox.__precision = this.__precision;
+          }
           return this;
         }
 

--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -927,6 +927,8 @@ define([
       var box = new NumberControllerBox(controller.object, controller.property,
           { min: controller.__min, max: controller.__max, step: controller.__step });
 
+      controller.__valueControllerBox = box;
+      
       common.each(['updateDisplay', 'onChange', 'onFinishChange'], function(method) {
         var pc = controller[method];
         var pb = box[method];


### PR DESCRIPTION
Added in the NumberControllerSlider a reference to the NumberControllerBox associated, to fix the displayed value precision bug for sliders when step is defined afterwards (via step() method instead of as option in add() method)