### PR TITLE
Fixed slider bar overflow issue

### DIFF
--- a/src/dat/gui/style.css
+++ b/src/dat/gui/style.css
@@ -271,7 +271,8 @@
       color: #fff; }
   .dg .c .slider {
     background: #303030;
-    cursor: ew-resize; }
+    cursor: ew-resize;
+    overflow: hidden; }
   .dg .c .slider-fg {
     background: #2fa1d6; }
   .dg .c .slider:hover {

--- a/src/dat/gui/style.scss
+++ b/src/dat/gui/style.scss
@@ -184,6 +184,7 @@ $input-color: lighten($background-color, 8.5%);
     .slider {
       background: $input-color;
       cursor: ew-resize;
+      overflow: hidden;
     }
 
     .slider-fg {


### PR DESCRIPTION
When a slider’s value exceeded its max value that bar overflows outside
of the slider. This occurs when the value is programmatically set by
listen().