### PR TITLE
Fix:Error occurs when attempt to rename a folder.

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -246,8 +246,8 @@ const GUI = function(pars) {
         set: function(v) {
           // TODO Check for collisions among sibling folders
           params.name = v;
-          if (titleRowName) {
-            titleRowName.innerHTML = params.name;
+          if (titleRow) {
+            titleRow.innerHTML = params.name;
           }
         }
       },


### PR DESCRIPTION
Fix:Error occurs when attempt to rename a folder.