### PR TITLE
Fix slider width for Chrome and Safari.

### DIFF
--- a/src/dat/gui/_structure.scss
+++ b/src/dat/gui/_structure.scss
@@ -176,7 +176,7 @@ $button-height: 20px;
 
   .slider {
     float: left;
-    width: 66%;
+    width: 60%;
     margin-left: -5px;
     margin-right: 0;
     height: 19px;


### PR DESCRIPTION
Relax the width of the slider div to 60% for Chrome and Safari browsers. On Firefox browser the div with text fits into the parent container, but for Chrome and Safari isn't enough and provokes the slider container to fall down under the input text, what makes it invisible of the visual layout.
This is mentioned in issue Number sliders are hidden #124.
