### PR TITLE
Make it possible to set a namespace for localStorage

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -1023,8 +1023,8 @@ function add(gui, object, property, params) {
 }
 
 function getLocalStorageHash(gui, key) {
-  // TODO how does this deal with multiple GUI's?
-  return document.location.href + '.' + key;
+  var namespace = localStorage.getItem('dat.gui.namespace') || document.location.href;
+  return 'dat.gui.' + namespace + '.' + key;
 }
 
 function addPresetOption(gui, name, setSelected) {


### PR DESCRIPTION
* Make it possible to set a namespace for localStorage, with fallback to document.location.href.
* Also prefix with 'dat.gui.' to avoid collisions.

When using dat.gui in multiple projects in the same browser, this becomes quite important, especially if they share variable names and such (same codebase).

Usage (to add in guide?):
``` javascript
localStorage.setItem('dat.gui.namespace', 'YourNamespace');
``` 

