### PR TITLE
Properly test localstorage availability

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -41,7 +41,7 @@ const DEFAULT_DEFAULT_PRESET_NAME = 'Default';
 
 const SUPPORTS_LOCAL_STORAGE = (function() {
   try {
-    return 'localStorage' in window && window.localStorage !== null;
+    return 'localStorage' in window && window.localStorage !== null && window.localStorage !== undefined;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
LocalStorage is not supposed to be available when browsing files
served from the filesystem (without any webserver). IE reports
window.localstorage as undefined in that case.
Source: http://caniuse.com/#search=localstorage