### PR TITLE
Update sassify dependency version from 2 to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.14.0",
     "babelify": "^7.3.0",
-    "sassify": "^2.0.0",
+    "sassify": "^4.0.0",
     "stringify": "^5.1.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
Hi! I hope this change won't break the build. I'm on windows and `npm install dat.gui` fails because sassify version is too old. Version 2 of sassify depends on a very old version of node-sass which the installer tries to build itself and that fails.

I did `git clone https://github.com/dataarts/dat.gui`, changed sassify dependency version to 4, and run `npm install <folder>` folder being the cloned folder and installation went fine.