### PR TITLE
Teach utils that async functions are still functions

### DIFF
--- a/src/dat/utils/common.js
+++ b/src/dat/utils/common.js
@@ -149,7 +149,7 @@ const Common = {
   },
 
   isFunction: function(obj) {
-    return Object.prototype.toString.call(obj) === '[object Function]';
+    return obj instanceof Function;
   }
 
 };


### PR DESCRIPTION
fixes #240 

Forget my other fix for this. I foolishly bundled other things with it.
This one only changes the utils/common's isFunction test to:
```

  isFunction: function(obj) {
    return obj instanceof Function;
  }
```