### PR TITLE
Attempt at listen fix

### DIFF
--- a/src/dat/controllers/Controller.js
+++ b/src/dat/controllers/Controller.js
@@ -17,6 +17,7 @@
  * @param {Object} object The object to be manipulated
  * @param {string} property The name of the property to be manipulated
  */
+
 class Controller {
   constructor(object, property) {
     this.initialValue = object[property];
@@ -92,7 +93,7 @@ class Controller {
       this.__onChange.call(this, newValue);
     }
 
-    this.updateDisplay();
+    this.updateDisplay(true);
     return this;
   }
 
@@ -110,7 +111,7 @@ class Controller {
    * with the object's current value.
    * @returns {Controller} this
    */
-  updateDisplay() {
+  updateDisplay(force) {
     return this;
   }
 

--- a/src/dat/controllers/NumberControllerBox.js
+++ b/src/dat/controllers/NumberControllerBox.js
@@ -94,11 +94,22 @@ class NumberControllerBox extends NumberController {
     dom.bind(this.__input, 'mousedown', onMouseDown);
     dom.bind(this.__input, 'keydown', function(e) {
       // When pressing enter, you can be as precise as you want.
-      if (e.keyCode === 13) {
-        _this.__truncationSuspended = true;
-        this.blur();
-        _this.__truncationSuspended = false;
-        onFinish();
+      const step = _this.__step || 1;
+      switch (e.keyCode) {
+        case 13:
+          _this.__truncationSuspended = true;
+          this.blur();
+          _this.__truncationSuspended = false;
+          onFinish();
+          break;
+        case 38:
+          var newVal = _this.getValue() + step;
+          _this.setValue(newVal);
+          break;
+        case 40: // down
+          var newVal = _this.getValue() - step;
+          _this.setValue(newVal);
+          break;
       }
     });
 
@@ -107,7 +118,8 @@ class NumberControllerBox extends NumberController {
     this.domElement.appendChild(this.__input);
   }
 
-  updateDisplay() {
+  updateDisplay(force) {
+    if (!force && dom.isActive(this.__input)) return this;
     this.__input.value = this.__truncationSuspended ? this.getValue() : roundToDecimal(this.getValue(), this.__precision);
     return super.updateDisplay();
   }

--- a/src/dat/controllers/OptionController.js
+++ b/src/dat/controllers/OptionController.js
@@ -24,7 +24,7 @@ import common from '../utils/common';
  * @param {Object} object The object to be manipulated
  * @param {string} property The name of the property to be manipulated
  * @param {Object|string[]} options A map of labels to acceptable values, or
- * a list of acceptable string values.
+* a list of acceptable string values.
  */
 class OptionController extends Controller {
   constructor(object, property, opts) {
@@ -75,10 +75,10 @@ class OptionController extends Controller {
     return toReturn;
   }
 
-  updateDisplay() {
-    if (dom.isActive(this.__select)) return this; // prevent number from updating if user is trying to manually update
+  updateDisplay(force) {
+    if (!force && dom.isActive(this.__select)) return this; // prevent number from updating if user is trying to manually update
     this.__select.value = this.getValue();
-    return super.updateDisplay();
+    return super.updateDisplay(force);
   }
 }
 


### PR DESCRIPTION
An attempt to de-clusterfy .listen,
whilte still allowing editing of input fields when(isActive)
but allowing setValue to cause updateDisplay, so events like keyboard events wilkl work... exhale..
-----
updateDisplay(force): skips active check (note force is false during the .___listening loop)
otherwise runs active check and doesnt update if dom.isActive(*element*)
----
fixes listen, while allowing editing, allows drag events, and re-added key up/down (which were blocked if checking isActive but not force)

isactive problems: fixes #206, #179
keyboard: fixes #195, (blocked before updateDisplay(force) created
possible related, but am confus:
#95: this is true. onChange is fired by setValue, onFInishChange only after slider/mouse event
#212: I don't follow this, though it seems related... a code example might help. I suspect he could updateDisplay(true) after whatever he's doing

withdrawing head from code in 3... 2.... 1....