### PR TITLE
Update hide boolean when GUI hide or show

### DIFF
--- a/src/dat/gui/GUI.js
+++ b/src/dat/gui/GUI.js
@@ -688,6 +688,7 @@ common.extend(
     * Hides the GUI.
     */
     hide: function() {
+      hide = true;
       this.domElement.style.display = 'none';
     },
 
@@ -695,6 +696,7 @@ common.extend(
     * Shows the GUI.
     */
     show: function() {
+      hide = false;
       this.domElement.style.display = '';
     },
 


### PR DESCRIPTION
The keyboard shortcut 'h' depends on the global boolean variable `hide`.

Since the `GUI.hide()` and `GUI.show()` methods only update the dom's display property and not the `hide` boolean, the 'h' key looses its sync after calling them.