### PR TITLE
Fix width on FunctionController property_name

### DIFF
--- a/example.html
+++ b/example.html
@@ -58,6 +58,11 @@
     var f3 = f2.addFolder('Nested Folder');
     f3.add(obj, 'growthSpeed');
 
+    obj['Button with a long description'] = function () {
+      console.log('Button with a long description pressed');
+    };
+    gui.add(obj, 'Button with a long description');
+
   </script>
 </body>
 </html>

--- a/src/dat/gui/_structure.scss
+++ b/src/dat/gui/_structure.scss
@@ -172,6 +172,11 @@ $button-height: 20px;
     text-overflow: ellipsis;
   }
 
+  /** Function controllers can use the entire width */
+  .cr.function .property-name {
+    width: 100%;
+  }
+
   /** Controller-half (right) */
   .c {
     float: left;


### PR DESCRIPTION
Before: Text descriptions for buttons (`FunctionController`) were being truncated unnecessarily to the same width as other Controllers that must share real estate with input elements.

This PR sets the css width for `FunctionController` elements to 100%.  I've added to `example.html` in case it's useful.

Before:
![Screenshot from 2021-09-07 09-23-56](https://user-images.githubusercontent.com/6442292/132352291-3c1a09c2-e959-43be-a034-fda33ae4f0b2.png)


After:
![Screenshot from 2021-09-07 09-22-46](https://user-images.githubusercontent.com/6442292/132352302-7b52e9af-cec2-4ec9-93a3-65b9fe29c597.png)

