### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/qunit.js
+++ b/tests/qunit.js
@@ -301,7 +301,7 @@ var QUnit = {
 	},
 
 	/**
-	 * Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
+	 * Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
 	 */
 	expect: function(asserts) {
 		config.current.expected = asserts;
@@ -482,7 +482,7 @@ var config = {
 	moduleDone: []
 };
 
-// Load paramaters
+// Load parameters
 (function() {
 	var location = window.location || { search: "", protocol: "file:" },
 		params = location.search.slice( 1 ).split( "&" ),
@@ -1070,7 +1070,7 @@ QUnit.equiv = function () {
 		// for string, boolean, number and null
 		function useStrictEquality(b, a) {
 			if (b instanceof a.constructor || a instanceof b.constructor) {
-				// to catch short annotaion VS 'new' annotation of a
+				// to catch short annotation VS 'new' annotation of a
 				// declaration
 				// e.g. var i = 1;
 				// var j = new Number(1);
@@ -1099,7 +1099,7 @@ QUnit.equiv = function () {
 			"regexp" : function(b, a) {
 				return QUnit.objectType(b) === "regexp"
 						&& a.source === b.source && // the regex itself
-						a.global === b.global && // and its modifers
+						a.global === b.global && // and its modifiers
 													// (gmi) ...
 						a.ignoreCase === b.ignoreCase
 						&& a.multiline === b.multiline;
@@ -1147,7 +1147,7 @@ QUnit.equiv = function () {
 
 			"object" : function(b, a) {
 				var i, j, loop;
-				var eq = true; // unless we can proove it
+				var eq = true; // unless we can prove it
 				var aProperties = [], bProperties = []; // collection of
 														// strings
 


### PR DESCRIPTION
There are small typos in:
- tests/qunit.js

Fixes:
- Should read `prove` rather than `proove`.
- Should read `parameters` rather than `paramaters`.
- Should read `modifiers` rather than `modifers`.
- Should read `guarantee` rather than `gurantee`.
- Should read `annotation` rather than `annotaion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md